### PR TITLE
Add hash to a licence

### DIFF
--- a/output_sbom.go
+++ b/output_sbom.go
@@ -31,12 +31,18 @@ type Component struct {
 	Version  string    `xml:"version"`
 	PURL     string    `xml:"purl"`
 	Licences []License `xml:"licenses>license"`
+	Hashes   []Hash    `xml:"hashes>hash"`
+}
+
+type Hash struct {
+	Alg   string `xml:"alg,attr"`
+	Value string `xml:",chardata"`
 }
 
 type License struct {
 	ID   *string `xml:"id,omitempty"`
 	Name *string `xml:"name,omitempty"`
-	URL  *string `xml:"url,omitempty"`
+	URL  *string `xml:"url,omitempty`
 }
 
 func NewComponent(m *module.Module) Component {
@@ -44,12 +50,24 @@ func NewComponent(m *module.Module) Component {
 		Path:    m.Path,
 		Version: m.Version,
 	}
-	return Component{
+
+	c := Component{
 		Type:    "library",
 		Name:    m.Path,
 		Version: m.Version,
 		PURL:    mod.PURL(),
 	}
+
+	if m.Hash != "" {
+		c.Hashes = []Hash{
+			{
+				Alg:   "SHA-256",
+				Value: m.Hash,
+			},
+		}
+	}
+
+	return c
 }
 
 func (c *Component) WithLicense(l *license.License, config *config.Config) {
@@ -89,8 +107,8 @@ func (c *Component) WithLicenseFallback(config *config.Config) {
 }
 
 type Module struct {
-	Path    string `json:"Path"`
-	Version string `json:"Version"`
+	Path    string
+	Version string
 }
 
 func (m Module) PURL() string {

--- a/output_sbom.go
+++ b/output_sbom.go
@@ -42,7 +42,7 @@ type Hash struct {
 type License struct {
 	ID   *string `xml:"id,omitempty"`
 	Name *string `xml:"name,omitempty"`
-	URL  *string `xml:"url,omitempty`
+	URL  *string `xml:"url,omitempty"`
 }
 
 func NewComponent(m *module.Module) Component {


### PR DESCRIPTION
The hash value included in the binary is the same as in go.mod.

Example go.mod entry:

github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=

The Hash is `h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=`